### PR TITLE
Fix AppTest assertion

### DIFF
--- a/app/src/test/java/org/example/AppTest.java
+++ b/app/src/test/java/org/example/AppTest.java
@@ -4,11 +4,14 @@
 package org.example;
 
 import org.junit.jupiter.api.Test;
+import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 
 class AppTest {
-    @Test void appHasAGreeting() {
+    @Test
+    void appHasAGreeting() {
         App classUnderTest = new App();
-        assertNotNull(classUnderTest.getGreeting(), "app should have a greeting");
+        Map<String, Object> result = classUnderTest.getGreeting("Test");
+        assertEquals("Hello Test!", result.get("message"));
     }
 }


### PR DESCRIPTION
## Summary
- update AppTest to use `getGreeting("Test")`
- assert greeting message is as expected

## Testing
- `gradle test` *(fails: Plugin [id: 'org.gradle.toolchains.foojay-resolver-convention', version: '0.10.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847328d071c832db0d36973bb61c0db